### PR TITLE
US62T70 Add users tree return and test

### DIFF
--- a/node_server/src/main/models/project.ts
+++ b/node_server/src/main/models/project.ts
@@ -21,7 +21,7 @@ const projectSchema = new Schema({
  * `TaskDoc` type.
  */
 export interface ProjectDoc extends TaskDoc {
-  subtasks: Array<typeof ObjectId>;
+  subtasks: Array<typeof ObjectId> | Array<TaskDoc>;
 }
 
 /**

--- a/node_server/src/main/models/task.ts
+++ b/node_server/src/main/models/task.ts
@@ -1,5 +1,7 @@
 import mongoose, { Model, Schema, Document } from 'mongoose';
 
+const ObjectId = mongoose.Types.ObjectId;
+
 /**
  * The mongoose schema for a Task in the database.
  */
@@ -17,6 +19,25 @@ export interface TaskDoc extends Document {
   title: string;
   note: string;
   date: Date;
+}
+
+/**
+ * Tests if an array is a TaskDoc array or an ObjectId array. This is used
+ * for the situation where `populate` is used in a mongoose query, likely for
+ * the `Project` class.
+ *
+ * @param {Array<typeof ObjectId> | Array<TaskDoc>} array the array to test
+ * if it is an ObjectId array or TaskDoc array.
+ * @returns {boolean} true if the array is a TaskDoc array
+ */
+export function isTaskDocArr(
+  array: Array<typeof ObjectId> | Array<TaskDoc>
+): array is Array<TaskDoc> {
+  if (array.length === 0) {
+    return false;
+  } else {
+    return (array as TaskDoc[])[0].title !== undefined;
+  }
 }
 
 /**

--- a/node_server/src/main/routes/users.ts
+++ b/node_server/src/main/routes/users.ts
@@ -95,17 +95,23 @@ function createUsersRouter(db: typeof mongoose): Router {
 
   /**
    * Gets a user with the spcified userId. If successful, it returns the user
-   * document.
+   * document and the populated tree of objects.
    */
-  router.get('/:userId', (req, res) => {
-    checkUserId(req.params.userId)
-      .then(userDoc => {
-        res.json(userDoc);
-      })
-      .catch(err => {
-        res.status(400);
-        res.json(err);
-      });
+  router.get('/:userId', async (req, res) => {
+    try {
+      const userDoc = await User.findOne({ _id: req.params.userId })
+        .populate({
+          path: 'projects',
+          populate: {
+            path: 'subtasks',
+          },
+        })
+        .exec();
+      res.json(userDoc);
+    } catch (err) {
+      res.status(400);
+      res.send(err);
+    }
   });
 
   /**


### PR DESCRIPTION
### Overview

Implements tree returning on user request. Now when a user is returned, the `projects` property has each project populated as well as each `subtask` within that project populated. Also a test was modified to test for this as well. 

### Includes:

- node_server/src/main/models/project.ts 
- node_server/src/main/models/task.ts 
- node_server/src/main/routes/users.ts 
- node_server/src/test/apiUsersTest.ts 

### Developer Checklist:

- [x] My code compiles and runs locally
- [x] The code follows the `QualityPolicy.md` file
- [x] My code has been developer-tested and includes unit tests
- [x] I have considered proper use of exceptions
- [x] I have eliminated IDE warnings

### Notes:

- This also adds an exported function to the `task.ts` file which is `isTaskDocArr` which helps with the type wrangling lol. Aka type guards 😅. 
- This was easier that expected to implement because apparently you can chain `populate` commands when building a mongoose query. Got the tip from [this stackoverflow post](https://stackoverflow.com/questions/18867628/mongoose-deep-population-populate-a-populated-field). Rock on!! 🎉

### Refs:

- [Task 73](https://tree.taiga.io/project/aneuhold-pointspire/task/73?kanban-status=1819336)
