### PR TITLE
T83 recursive task querying

### DIFF
--- a/node_server/src/main/models/project.ts
+++ b/node_server/src/main/models/project.ts
@@ -13,7 +13,7 @@ const projectSchema = new Schema({
   },
   note: String,
   date: { type: Date, default: Date.now },
-  subtasks: [{ type: ObjectId, ref: 'Task' }],
+  subtasks: [{ type: ObjectId, ref: 'Task', default: [] }],
 });
 
 /**
@@ -34,10 +34,10 @@ export type ProjectDoc = TaskDoc;
 export function isProjectDocArr(
   array: Array<typeof ObjectId> | Array<ProjectDoc>
 ): array is Array<ProjectDoc> {
-  if (array.length === 0) {
-    return false;
-  } else {
+  if (array && array.length !== 0) {
     return (array as ProjectDoc[])[0].title !== undefined;
+  } else {
+    return false;
   }
 }
 

--- a/node_server/src/main/models/project.ts
+++ b/node_server/src/main/models/project.ts
@@ -29,7 +29,8 @@ export type ProjectDoc = TaskDoc;
  *
  * @param {Array<typeof ObjectId> | Array<ProjectDoc>} array the array to test
  * if it is an ObjectId array or ProjectDoc array.
- * @returns {boolean} true if the array is a ProjectDoc array
+ * @returns {boolean} true if the array is a ProjectDoc array, and false if it
+ * is not or the array is empty
  */
 export function isProjectDocArr(
   array: Array<typeof ObjectId> | Array<ProjectDoc>

--- a/node_server/src/main/models/project.ts
+++ b/node_server/src/main/models/project.ts
@@ -20,9 +20,7 @@ const projectSchema = new Schema({
  * The type representing a Project document in the database. This extends the
  * `TaskDoc` type.
  */
-export interface ProjectDoc extends TaskDoc {
-  subtasks: Array<typeof ObjectId> | Array<TaskDoc>;
-}
+export type ProjectDoc = TaskDoc;
 
 /**
  * Tests if an array is a ProjectDoc array or an ObjectId array. This is used

--- a/node_server/src/main/models/task.ts
+++ b/node_server/src/main/models/task.ts
@@ -20,7 +20,7 @@ export interface TaskDoc extends Document {
   title: string;
   note: string;
   date: Date;
-  subtasks: Array<typeof ObjectId>;
+  subtasks: Array<typeof ObjectId> | Array<TaskDoc>;
 }
 
 /**

--- a/node_server/src/main/models/task.ts
+++ b/node_server/src/main/models/task.ts
@@ -36,7 +36,8 @@ export interface TaskDoc extends Document {
  *
  * @param {Array<typeof ObjectId> | Array<TaskDoc>} array the array to test
  * if it is an ObjectId array or TaskDoc array.
- * @returns {boolean} true if the array is a TaskDoc array
+ * @returns {boolean} true if the array is a TaskDoc array and false if it is
+ * not or the array is empty
  */
 export function isTaskDocArr(
   array: Array<typeof ObjectId> | Array<TaskDoc>

--- a/node_server/src/main/models/task.ts
+++ b/node_server/src/main/models/task.ts
@@ -9,6 +9,7 @@ const taskSchema = new Schema({
   title: String,
   note: String,
   date: { type: Date, default: Date.now },
+  subtasks: { type: ObjectId, ref: 'Task' },
 });
 
 /**
@@ -19,6 +20,7 @@ export interface TaskDoc extends Document {
   title: string;
   note: string;
   date: Date;
+  subtasks: Array<typeof ObjectId>;
 }
 
 /**

--- a/node_server/src/main/models/task.ts
+++ b/node_server/src/main/models/task.ts
@@ -9,7 +9,13 @@ const taskSchema = new Schema({
   title: String,
   note: String,
   date: { type: Date, default: Date.now },
-  subtasks: { type: ObjectId, ref: 'Task' },
+  subtasks: [
+    {
+      type: ObjectId,
+      ref: 'Task',
+      default: new Array<typeof ObjectId>(),
+    },
+  ],
 });
 
 /**

--- a/node_server/src/test/apiUsersTest.ts
+++ b/node_server/src/test/apiUsersTest.ts
@@ -77,13 +77,6 @@ describe('GET /id', () => {
         done();
       });
   });
-  it('should return a tree of all the projects and subtasks if the user has them', async () => {
-    const res = await chai.request(Globals.app).get(`/api/users/tree/test`);
-    console.log(
-      `The body of the response is: ${JSON.stringify(res.body, null, 2)}`
-    );
-    assert.isTrue(true);
-  });
 });
 
 describe('PATCH /id', () => {

--- a/node_server/src/test/apiUsersTest.ts
+++ b/node_server/src/test/apiUsersTest.ts
@@ -77,6 +77,13 @@ describe('GET /id', () => {
         done();
       });
   });
+  it('should return a tree of all the projects and subtasks if the user has them', async () => {
+    const res = await chai.request(Globals.app).get(`/api/users/tree/test`);
+    console.log(
+      `The body of the response is: ${JSON.stringify(res.body, null, 2)}`
+    );
+    assert.isTrue(true);
+  });
 });
 
 describe('PATCH /id', () => {


### PR DESCRIPTION
### Overview

Successfully implemented the recursive user tree population on the `/api/users/id` endpoint. This works for any levels deep of sub-tasks. It does take a while to complete though because each population is executed individually. It would be nice to be able to do it all in one request to the MongoDB, but it seems a bit complicated at the moment getting lookup or graphLookup to work right. Given the time constraints, this method seemed necessary.

### Includes:

- node_server/src/main/models/project.ts 
- node_server/src/main/models/task.ts 
- node_server/src/main/routes/users.ts 

### Developer Checklist:

- [x] My code compiles and runs locally
- [x] The code follows the `QualityPolicy.md` file
- [x] My code has been developer-tested and includes unit tests
- [x] I have considered proper use of exceptions
- [x] I have eliminated IDE warnings

### Notes:

- Currently making all the projects, tasks, subtasks, and more subtasks takes too long to test (physically too many milliseconds, not too long to code), so the test times out. So there isn't a test specifically to make sure this behavior reflects n-levels deep. But it was tested manually where timeouts do not occur, and it works great :) 
- In the future it would be nice to have a single lookup that performs the
sweep of tasks or something, or maybe a graphLookup, then assemble those
aka [marshalling](https://en.wikipedia.org/wiki/Marshalling_(computer_science)) into the completed UserDoc.
- Using `map` on an array while using `async`, for example `array.map(async value => {//some func});` returns an array of promises and executes asynchronously. That is why `Promise.all` is being used on those calls. 

### Refs:

- [Task 83](https://tree.taiga.io/project/aneuhold-pointspire/task/83?kanban-status=1822896)
