### PR TITLE
US123T126 Change project expansion icon to

### DIFF
--- a/client/src/main/components/TaskExpanderButton.tsx
+++ b/client/src/main/components/TaskExpanderButton.tsx
@@ -16,15 +16,17 @@ function TaskExpanderButton(props: TaskExpanderButtonProps): JSX.Element {
   return (
     <Grid item>
       <Tooltip title={open ? 'Show Less' : 'Show More'}>
-        <IconButton
-          disabled={parent.subtasks.length === 0}
-          aria-label="subtask-expander"
-          onClick={() => {
-            setOpen(!open);
-          }}
-        >
-          {open ? <ExpandMoreIcon /> : <ChevronRightIcon />}
-        </IconButton>
+        <span>
+          <IconButton
+            disabled={parent.subtasks.length === 0}
+            aria-label="subtask-expander"
+            onClick={() => {
+              setOpen(!open);
+            }}
+          >
+            {open ? <ExpandMoreIcon /> : <ChevronRightIcon />}
+          </IconButton>
+        </span>
       </Tooltip>
     </Grid>
   );

--- a/client/src/main/components/TaskExpanderButton.tsx
+++ b/client/src/main/components/TaskExpanderButton.tsx
@@ -1,6 +1,7 @@
 import { Grid, IconButton } from '@material-ui/core';
-import UpIcon from '@material-ui/icons/ArrowUpward';
-import DownIcon from '@material-ui/icons/ArrowDownward';
+import ChevronRightIcon from '@material-ui/icons/ChevronRight';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import Tooltip from '@material-ui/core/Tooltip';
 import React from 'react';
 import { Task, Project } from '../logic/dbTypes';
 
@@ -14,15 +15,17 @@ function TaskExpanderButton(props: TaskExpanderButtonProps): JSX.Element {
   const { parent, setOpen, open } = props;
   return (
     <Grid item>
-      <IconButton
-        disabled={parent.subtasks.length === 0}
-        aria-label="subtask-expander"
-        onClick={() => {
-          setOpen(!open);
-        }}
-      >
-        {open ? <UpIcon /> : <DownIcon />}
-      </IconButton>
+      <Tooltip title={open ? 'Show Less' : 'Show More'}>
+        <IconButton
+          disabled={parent.subtasks.length === 0}
+          aria-label="subtask-expander"
+          onClick={() => {
+            setOpen(!open);
+          }}
+        >
+          {open ? <ExpandMoreIcon /> : <ChevronRightIcon />}
+        </IconButton>
+      </Tooltip>
     </Grid>
   );
 }


### PR DESCRIPTION
### Overview

Changes project expansion/contraction icons to chevrons, what vscode uses to expand/contract a code block. Also adds a dynamic "Show More"/"Show Less" tooltip for the button.

### Includes:

- client/src/main/components/TaskExpanderButton.tsx

### Developer Checklist:

- [x] My code compiles and runs locally
- [x] The code follows the `QualityPolicy.md` file
- [ ] My code has been developer-tested and includes unit tests
- [x] I have considered proper use of exceptions
- [x] I have eliminated IDE warnings

### Notes:

![Expand](https://i.imgur.com/9AFSati.png)
![Contact](https://i.imgur.com/vGKNpuW.png)

### Refs:

- [US123](https://tree.taiga.io/project/aneuhold-pointspire/us/123?milestone=268243)
