### PR TITLE
Us134 save button

### DIFF
--- a/client/src/main/App.tsx
+++ b/client/src/main/App.tsx
@@ -107,6 +107,18 @@ class App extends React.Component<AppProps, AppState> {
     GlobalState.setState = (state: AppState) => {
       this.setState(state);
     };
+
+    // Prevent unload of the app if the user has any unsaved changes
+    window.addEventListener('beforeunload', e => {
+      const { pendingChanges } = this.state;
+      if (pendingChanges !== PendingChanges.Saved) {
+        // Prevent unload
+        e.preventDefault();
+        e.returnValue = '';
+      }
+      // Allow unload
+      delete e.returnValue;
+    });
   }
 
   setProjectIds(updatedProjectIds: Array<string>): void {

--- a/client/src/main/App.tsx
+++ b/client/src/main/App.tsx
@@ -9,8 +9,7 @@ import { AllUserData } from './logic/dbTypes';
 import ProjectTable from './components/ProjectTable';
 import { getUserData, getTestUserData } from './logic/fetchMethods';
 import baseThemeOptions from './AppTheme';
-import ClientData from './logic/ClientData';
-import { PendingChanges } from './logic/savingTimer';
+import ClientData from './logic/ClientData/ClientData';
 
 /**
  * Used to determine the severity of an alert for the snackbar of the app.
@@ -39,11 +38,6 @@ type AppState = {
   projectIds: Array<string> | null;
 
   appTheme: Theme;
-
-  /**
-   * Indicates if user initiated changes are pending to be saved
-   */
-  pendingChanges: PendingChanges;
 };
 
 type AppProps = unknown;
@@ -75,7 +69,6 @@ class App extends React.Component<AppProps, AppState> {
       snackBarText: 'unknown',
       appTheme: createMuiTheme(baseThemeOptions),
       projectIds: null,
-      pendingChanges: PendingChanges.Saved,
     };
 
     this.handleSnackBarClose = this.handleSnackBarClose.bind(this);
@@ -102,23 +95,6 @@ class App extends React.Component<AppProps, AppState> {
       ClientData.setUser(userData.user);
       this.setProjectIds(userData.user.projects);
     }
-
-    // Global state access hack
-    GlobalState.setState = (state: AppState) => {
-      this.setState(state);
-    };
-
-    // Prevent unload of the app if the user has any unsaved changes
-    window.addEventListener('beforeunload', e => {
-      const { pendingChanges } = this.state;
-      if (pendingChanges !== PendingChanges.Saved) {
-        // Prevent unload
-        e.preventDefault();
-        e.returnValue = '';
-      }
-      // Allow unload
-      delete e.returnValue;
-    });
   }
 
   setProjectIds(updatedProjectIds: Array<string>): void {
@@ -168,7 +144,6 @@ class App extends React.Component<AppProps, AppState> {
       snackBarText,
       appTheme,
       projectIds,
-      pendingChanges,
     } = this.state;
     const { handleSnackBarClose, alert, setTheme } = this;
     return (
@@ -179,7 +154,6 @@ class App extends React.Component<AppProps, AppState> {
             alert={alert}
             appTheme={appTheme}
             setTheme={setTheme}
-            pendingChanges={pendingChanges}
           />
           {projectIds ? <ProjectTable /> : <></>}
           <Snackbar

--- a/client/src/main/App.tsx
+++ b/client/src/main/App.tsx
@@ -51,13 +51,6 @@ if (process.env.REACT_APP_AUTH === 'LOCAL') {
 }
 
 /**
- * A somewhat hacky way to set the state of the app in external functions.
- * There must be a better way to do this! See componentDidMount for `setState`
- * binding.
- */
-export const GlobalState: { [key: string]: Function } = {};
-
-/**
  * Represents the main application window.
  */
 class App extends React.Component<AppProps, AppState> {

--- a/client/src/main/components/CompletableRow/CompletableRow.tsx
+++ b/client/src/main/components/CompletableRow/CompletableRow.tsx
@@ -19,7 +19,7 @@ import PriorityButton from '../PriorityButton/PriorityButton';
 import TaskExpanderButton from './TaskExpanderButton';
 import NoteButton from './NoteButton';
 import CompletedCheckbox from './CompletedCheckbox';
-import ClientData from '../../logic/ClientData';
+import ClientData from '../../logic/ClientData/ClientData';
 
 function styles(theme: Theme) {
   return createStyles({

--- a/client/src/main/components/CompletableRow/CompletedCheckbox.tsx
+++ b/client/src/main/components/CompletableRow/CompletedCheckbox.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Checkbox } from '@material-ui/core';
 import { CompletableType, Completable } from '../../logic/dbTypes';
-import ClientData from '../../logic/ClientData';
+import ClientData from '../../logic/ClientData/ClientData';
 
 export type CompletedCheckboxProps = {
   className?: string;

--- a/client/src/main/components/CompletableRow/DateInput.tsx
+++ b/client/src/main/components/CompletableRow/DateInput.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { MaterialUiPickersDate } from '@material-ui/pickers/typings/date';
 import { DatePicker } from '@material-ui/pickers';
-import ClientData from '../../logic/ClientData';
+import ClientData from '../../logic/ClientData/ClientData';
 import { CompletableType } from '../../logic/dbTypes';
 
 export type DateInputProps = {

--- a/client/src/main/components/CompletableRow/NoteInput.tsx
+++ b/client/src/main/components/CompletableRow/NoteInput.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { TextField } from '@material-ui/core';
 import { resetTimer } from '../../logic/savingTimer';
-import ClientData from '../../logic/ClientData';
+import ClientData from '../../logic/ClientData/ClientData';
 import { CompletableType } from '../../logic/dbTypes';
 
 export type NoteInputProps = {

--- a/client/src/main/components/PriorityButton/PriorityButton.tsx
+++ b/client/src/main/components/PriorityButton/PriorityButton.tsx
@@ -8,7 +8,7 @@ import {
 } from '@material-ui/core';
 import PriorityDialog from './PriorityDialog';
 import { CompletableType } from '../../logic/dbTypes';
-import ClientData from '../../logic/ClientData';
+import ClientData from '../../logic/ClientData/ClientData';
 
 function styles() {
   return createStyles({

--- a/client/src/main/components/PriorityButton/PriorityDialog.tsx
+++ b/client/src/main/components/PriorityButton/PriorityDialog.tsx
@@ -5,7 +5,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import { DialogActions, Button } from '@material-ui/core';
 import PriorityInput from './PriorityInput';
 import { CompletableType } from '../../logic/dbTypes';
-import ClientData from '../../logic/ClientData';
+import ClientData from '../../logic/ClientData/ClientData';
 
 type PriorityDialogProps = {
   open: boolean;

--- a/client/src/main/components/ProjectTable.tsx
+++ b/client/src/main/components/ProjectTable.tsx
@@ -9,7 +9,7 @@ import {
 import sortingFunctions from '../logic/sortingFunctions';
 import SortInput from './SortInput';
 import CompletableRow from './CompletableRow/CompletableRow';
-import ClientData from '../logic/ClientData';
+import ClientData from '../logic/ClientData/ClientData';
 // import arraysAreShallowEqual from '../logic/comparisonFunctions';
 
 /* This eslint comment is not a good solution, but the alternative seems to be 

--- a/client/src/main/components/SettingsDialog/SettingsDialog.tsx
+++ b/client/src/main/components/SettingsDialog/SettingsDialog.tsx
@@ -18,7 +18,7 @@ import { AlertFunction } from '../../App';
 import FontSizeSetting from './FontSizeSetting';
 import baseThemeOptions from '../../AppTheme';
 import { setCookie, ClientCookies } from '../../logic/clientCookies';
-import ClientData from '../../logic/ClientData';
+import ClientData from '../../logic/ClientData/ClientData';
 
 type SettingsDialogProps = {
   open: boolean;

--- a/client/src/main/components/SimpleTextInput.tsx
+++ b/client/src/main/components/SimpleTextInput.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { TextField } from '@material-ui/core';
 import { resetTimer } from '../logic/savingTimer';
-import ClientData from '../logic/ClientData';
+import ClientData from '../logic/ClientData/ClientData';
 import { CompletableType } from '../logic/dbTypes';
 
 export type SimpleTextInputProps = {

--- a/client/src/main/components/TopMenuBar.tsx
+++ b/client/src/main/components/TopMenuBar.tsx
@@ -25,6 +25,7 @@ import LoginDialog from './LoginDialog';
 import { AlertFunction } from '../App';
 import { logout } from '../logic/fetchMethods';
 import ClientData from '../logic/ClientData';
+import { PendingChanges, manualSave } from '../logic/savingTimer';
 
 /* This eslint comment is not a good solution, but the alternative seems to be 
 ejecting from create-react-app */
@@ -54,10 +55,18 @@ export interface TopMenuBarProps extends WithStyles<typeof styles> {
   githubClientId: string;
   appTheme: Theme;
   setTheme: (theme: Theme) => void;
+  pendingChanges: PendingChanges;
 }
 
 function TopMenuBar(props: TopMenuBarProps): JSX.Element {
-  const { alert, setTheme, appTheme, githubClientId, classes } = props;
+  const {
+    alert,
+    setTheme,
+    appTheme,
+    githubClientId,
+    classes,
+    pendingChanges,
+  } = props;
   /**
    * The items for the drawer that pops out of the left hand side.
    */
@@ -218,6 +227,11 @@ function TopMenuBar(props: TopMenuBarProps): JSX.Element {
           <Typography variant="h6" className={classes.title}>
             PointSpire
           </Typography>
+          {loggedIn && (
+            <Button color="inherit" onClick={manualSave}>
+              {pendingChanges}
+            </Button>
+          )}
           <Button
             color="inherit"
             onClick={loggedIn ? logout : createSetLoginOpenHandler(true)}

--- a/client/src/main/logic/ClientData/AppSaveStatus.ts
+++ b/client/src/main/logic/ClientData/AppSaveStatus.ts
@@ -1,0 +1,90 @@
+/**
+ * pendingChanges state enum
+ */
+export enum SavedStatus {
+  Save = 'Save',
+  Saving = 'Saving',
+  Saved = 'Saved',
+}
+
+export type SaveListenerCallback = (updatedStatus: SavedStatus) => void;
+
+type SaveListeners = {
+  [listenerId: string]: SaveListenerCallback;
+};
+
+/**
+ * Contains the operations to listen to and set the save status of the
+ * application.
+ */
+export class AppSaveStatus {
+  /**
+   * Indicates the status of changes of the user.
+   */
+  private static savedStatus: SavedStatus = SavedStatus.Saved;
+
+  /**
+   * The listeners of the save status changes.
+   */
+  private static saveListeners: SaveListeners = {};
+
+  /**
+   * Notifies and runs all the callbacks for the save status listeners.
+   *
+   * @param {SavedStatus} updatedStatus the updated SavedStatus
+   */
+  private static notifySaveListeners(updatedStatus: SavedStatus) {
+    Object.values(this.saveListeners).forEach(callback => {
+      callback(updatedStatus);
+    });
+  }
+
+  /**
+   * Gets the current saved status of the application.
+   *
+   * @returns {SavedStatus} the current saved status
+   */
+  static getStatus(): SavedStatus {
+    return this.savedStatus;
+  }
+
+  /**
+   * Updates the applications saved state.
+   *
+   * @param {SavedStatus} updatedStatus the updated save status
+   */
+  static setStatus(updatedStatus: SavedStatus) {
+    if (this.savedStatus !== updatedStatus) {
+      this.savedStatus = updatedStatus;
+      this.notifySaveListeners(updatedStatus);
+    }
+  }
+
+  /**
+   * Adds the given callback to the list of listeners for chagnes in the save
+   * status of the application.
+   *
+   * @param {string} listenerId the unique ID of the listener. Should be
+   * unique among different instances of components in the application.
+   * @param {SaveListenerCallback} callback the callback to run when a change
+   * in the save status occurs
+   */
+  static addSavedStatusListener(
+    listenerId: string,
+    callback: SaveListenerCallback
+  ) {
+    this.saveListeners[listenerId] = callback;
+  }
+
+  /**
+   * Removess the listener with the given ID from the list of listeners for the
+   * save status.
+   *
+   * @param {string} listenerId the listener ID
+   */
+  static removeSavedStatusListener(listenerId: string) {
+    if (this.saveListeners[listenerId]) {
+      delete this.saveListeners[listenerId];
+    }
+  }
+}

--- a/client/src/main/logic/ClientData/ClientData.ts
+++ b/client/src/main/logic/ClientData/ClientData.ts
@@ -6,8 +6,8 @@ import {
   User,
   Project,
   Task,
-} from './dbTypes';
-import scheduleCallback from './savingTimer';
+} from '../dbTypes';
+import scheduleCallback from '../savingTimer';
 import {
   patchProject,
   patchTask,
@@ -16,7 +16,7 @@ import {
   deleteTaskById,
   postNewProject,
   postNewTask,
-} from './fetchMethods';
+} from '../fetchMethods';
 
 /**
  * The callback which will be called if any changes are made to a Completable.

--- a/client/src/main/logic/sortingFunctions.ts
+++ b/client/src/main/logic/sortingFunctions.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import { CompletableType } from './dbTypes';
-import ClientData from './ClientData';
+import ClientData from './ClientData/ClientData';
 
 function getCompletables(type: CompletableType) {
   if (type === 'project') {


### PR DESCRIPTION
### Overview

This PR adds a manual save button whose text reflects the state of any pending changes yet to be saved. The button doesn't render unless logged in and pressing it cancels any currently scheduled saves, forces save of pending changes, and restarts the save timer. If any changes are pending the browser will prompt the user if they try to unload (refresh, close, or navigate away from) the app with the browser's default message (no way to change this message at the time as it is considered a security issue by the browsers).

### Includes:

- client/src/main/App.tsx
- client/src/main/components/TopMenuBar.tsx
- client/src/main/logic/savingTimer.ts

### Developer Checklist:

- [x] My code compiles and runs locally
- [x] The code follows the `QualityPolicy.md` file
- [x] My code has been developer-tested and includes unit tests
- [x] I have considered proper use of exceptions
- [x] I have eliminated IDE warnings

### Notes:

![Saving](https://i.imgur.com/9gcq2Id.gif)

![Unload Prevention](https://i.imgur.com/9cxBWNv.gif)

### Refs:

- [US134](https://tree.taiga.io/project/aneuhold-pointspire/us/134?milestone=269364)
